### PR TITLE
Fix signature of RPLidar::begin()

### DIFF
--- a/RPLidarDriver/RPLidar.cpp
+++ b/RPLidarDriver/RPLidar.cpp
@@ -45,7 +45,7 @@ RPLidar::~RPLidar()
 }
 
 // open the given serial interface and try to connect to the RPLIDAR
-bool RPLidar::begin(HardwareSerial &serialobj)
+void RPLidar::begin(HardwareSerial &serialobj)
 {
     if (isOpen()) {
       end(); 

--- a/RPLidarDriver/RPLidar.h
+++ b/RPLidarDriver/RPLidar.h
@@ -53,7 +53,7 @@ public:
     ~RPLidar();
 
     // open the given serial interface and try to connect to the RPLIDAR
-    bool begin(HardwareSerial &serialobj);
+    void begin(HardwareSerial &serialobj);
 
     // close the currently opened serial interface
     void end();

--- a/RPLidarDriver/library.json
+++ b/RPLidarDriver/library.json
@@ -1,0 +1,26 @@
+{
+    "name": "RPLidar (DanCrank fork)",
+    "version": "1.0.2",
+    "description": "Local fork of RPLidar driver",
+    "keywords": "lidar, rplidar",
+    "repository":
+    {
+      "type": "git",
+      "url": "https://github.com/DanCrank/rplidar_arduino"
+    },
+    "authors":
+    [
+      {
+        "name": "Robopeak",
+        "email": "support@robopeak.com",
+        "url": "https://www.robopeak.com"
+      },
+      {
+        "name": "Dan Crank",
+        "email": "danno@danno.org"
+      }
+    ],
+    "license": "MIT",
+    "frameworks": "*",
+    "platforms": "*"
+  }

--- a/RPLidarDriver/library.json
+++ b/RPLidarDriver/library.json
@@ -20,7 +20,7 @@
         "email": "danno@danno.org"
       }
     ],
-    "license": "MIT",
+    "license": "GPL-2.0-only",
     "frameworks": "*",
     "platforms": "*"
   }


### PR DESCRIPTION
RPLidar::begin() was declared to return bool when
it actually returns void. This can lock up some
microcontrollers.